### PR TITLE
Fix typo on GraphQL identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The language identifier comment must appear before the opening backtick for the 
 | git_commit | COMMIT_EDITMSG, MERGE_MSG |
 | git_rebase | git-rebase-todo |
 | go | go, golang |
-| graphql | qgl, graphql |
+| graphql | gql, qgl, graphql |
 | groovy | groovy, gvy |
 | pug | jade, pug |
 | js | js, jsx, javascript, es6, mjs |

--- a/build/languages.js
+++ b/build/languages.js
@@ -1,12 +1,12 @@
 /**
  * List of languages
- * 
+ *
  * name: Human readable indentifier for the langauge
- * 
+ *
  * language: vscode language identifier
- * 
+ *
  * identifiers: Strings used in comments to identify language
- * 
+ *
  * source: Name of the toplevel textmate scope for the language
  */
 const languages = [
@@ -38,7 +38,7 @@ const languages = [
     { name: 'git_commit', identifiers: ['COMMIT_EDITMSG', 'MERGE_MSG'], source: 'text.git-commit' },
     { name: 'git_rebase', identifiers: ['git-rebase-todo'], source: 'text.git-rebase' },
     { name: 'go', language: 'go', identifiers: ['go', 'golang'], source: 'source.go' },
-    { name: 'graphql', language: 'graphql', identifiers: ['qgl', 'graphql'], source: 'source.graphql' },
+    { name: 'graphql', language: 'graphql', identifiers: ['gql', 'qgl', 'graphql'], source: 'source.graphql' },
     { name: 'groovy', language: 'groovy', identifiers: ['groovy', 'gvy'], source: 'source.groovy' },
     { name: 'pug', language: 'pug', identifiers: ['jade', 'pug'], source: 'text.pug' },
     { name: 'js', language: 'javascript', identifiers: ['js', 'jsx', 'javascript', 'es6', 'mjs'], source: 'source.js' },

--- a/syntaxes/grammar.json
+++ b/syntaxes/grammar.json
@@ -3,7 +3,7 @@
     "injectionSelector": "L:source.js -comment -(string - meta.embedded), L:source.jsx -comment -(string - meta.embedded), L:source.js.jsx -comment -(string - meta.embedded), L:source.ts -comment -(string - meta.embedded), L:source.tsx -comment -(string - meta.embedded)",
     "patterns": [
         {
-            "begin": "(?i)(/)(?=(\\*\\s*\\b(?:css|css\\.erb|html|htm|shtml|xhtml|inc|tmpl|tpl|ini|conf|java|bsh|lua|Makefile|makefile|GNUmakefile|OCamlMakefile|perl|pl|pm|pod|t|PL|psgi|vcl|R|r|s|S|Rprofile|ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile\\.lock|Thorfile|Puppetfile|php|php3|php4|php5|phpt|phtml|aw|ctp|sql|ddl|dml|vb|xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml|xsl|xslt|yaml|yml|bat|batch|clj|cljs|clojure|coffee|Cakefile|coffee\\.erb|c|h|cpp|c\\+\\+|cxx|patch|diff|rej|dockerfile|Dockerfile|COMMIT_EDITMSG|MERGE_MSG|git\\-rebase\\-todo|go|golang|qgl|graphql|groovy|gvy|jade|pug|js|jsx|javascript|es6|mjs|regexp|json|sublime\\-settings|sublime\\-menu|sublime\\-keymap|sublime\\-mousemap|sublime\\-theme|sublime\\-build|sublime\\-project|sublime\\-completions|less|md|markdown|mjml|objectivec|objective\\-c|mm|objc|obj\\-c|m|h|scss|perl6|p6|pl6|pm6|nqp|powershell|ps1|psm1|psd1|python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi|re|rust|rs|scala|sbt|shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|\\.textmate_init|typescript|ts|tsx|cs|csharp|c\\#|fs|fsharp|f\\#|dart|glsl|liquid|sparql)\\b\\s*\\*/)\\s*`)",
+            "begin": "(?i)(/)(?=(\\*\\s*\\b(?:css|css\\.erb|html|htm|shtml|xhtml|inc|tmpl|tpl|ini|conf|java|bsh|lua|Makefile|makefile|GNUmakefile|OCamlMakefile|perl|pl|pm|pod|t|PL|psgi|vcl|R|r|s|S|Rprofile|ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile\\.lock|Thorfile|Puppetfile|php|php3|php4|php5|phpt|phtml|aw|ctp|sql|ddl|dml|vb|xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml|xsl|xslt|yaml|yml|bat|batch|clj|cljs|clojure|coffee|Cakefile|coffee\\.erb|c|h|cpp|c\\+\\+|cxx|patch|diff|rej|dockerfile|Dockerfile|COMMIT_EDITMSG|MERGE_MSG|git\\-rebase\\-todo|go|golang|gql|qgl|graphql|groovy|gvy|jade|pug|js|jsx|javascript|es6|mjs|regexp|json|sublime\\-settings|sublime\\-menu|sublime\\-keymap|sublime\\-mousemap|sublime\\-theme|sublime\\-build|sublime\\-project|sublime\\-completions|less|md|markdown|mjml|objectivec|objective\\-c|mm|objc|obj\\-c|m|h|scss|perl6|p6|pl6|pm6|nqp|powershell|ps1|psm1|psd1|python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi|re|rust|rs|scala|sbt|shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|\\.textmate_init|typescript|ts|tsx|cs|csharp|c\\#|fs|fsharp|f\\#|dart|glsl|liquid|sparql)\\b\\s*\\*/)\\s*`)",
             "beginCaptures": {
                 "1": {
                     "name": "comment.block.ts"
@@ -733,7 +733,7 @@
         "commentTaggedTemplate-graphql": {
             "name": "string.js.taggedTemplate.commentTaggedTemplate.graphql",
             "contentName": "meta.embedded.block.graphql",
-            "begin": "(?i)(\\*\\s*\\b(?:qgl|graphql)\\b\\s*\\*/)\\s*(`)",
+            "begin": "(?i)(\\*\\s*\\b(?:gql|qgl|graphql)\\b\\s*\\*/)\\s*(`)",
             "beginCaptures": {
                 "1": {
                     "name": "comment.block.ts"


### PR DESCRIPTION
When GraphQL support has been added to the plugin (PR #4), a [typo was added](https://github.com/mjbvz/vscode-comment-tagged-templates/pull/4#discussion_r534640580) and not fixed.

Following [comment](https://github.com/mjbvz/vscode-comment-tagged-templates/issues/2#issuecomment-1738794184) on #2, this PR is fixing that while keeping the old typo for support for existing use of `qgl` identifier.