### PR TITLE
Fix JS / TS backtick (`) escape in SQL

### DIFF
--- a/syntaxes/grammar.json
+++ b/syntaxes/grammar.json
@@ -422,7 +422,15 @@
                 }
             },
             "end": "(?=`)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.string.template.end.js"
+                }
+            },
             "patterns": [
+                {
+                    "match": "\\\\`", "name": "constant.character.escape.js"
+                },
                 {
                     "include": "source.sql"
                 },


### PR DESCRIPTION
Currently:
```js
/*sql*/` SELECT \`column\` from \`table\` `
```

breaks highlight. adding endCapture and additional pattern gives pattern matcher additional insights without blindly considering backtick as end