### PR TITLE
Add yaml frontmatter to markdown.

### DIFF
--- a/syntaxes/grammar.json
+++ b/syntaxes/grammar.json
@@ -908,6 +908,20 @@
             "end": "(?=`)",
             "patterns": [
                 {
+                    "begin": "\\s*(---)\\s*$",
+                    "beginCaptures": {
+                        "0": { "name": "punctuation.definition.front-matter.markdown" }
+                    },
+                    "end": "^\\s*(---)\\s*$",
+                    "endCaptures": {
+                        "0": { "name": "punctuation.definition.front-matter.markdown" }
+                    },
+                    "name": "meta.embedded.block.front-matter.yaml",
+                    "patterns": [
+                        { "include": "source.yaml" }
+                    ]
+                },
+                {
                     "include": "text.html.markdown"
                 },
                 {


### PR DESCRIPTION
This allows the extension to properly highlight yaml frontmatter in a markdown string.